### PR TITLE
Add LRU cache for looking up entities with a given component set

### DIFF
--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -1,4 +1,4 @@
-from .world import World
+from .world import CachedWorld, World
 from .templates import Processor
 
 __version__ = "0.9"
@@ -6,4 +6,4 @@ __author__ = "Benjamin Moran"
 __license__ = "MIT"
 __copyright__ = "Benjamin Moran"
 
-__all__ = ["World", "Processor"]
+__all__ = ("CachedWorld", "Processor", "World")

--- a/esper/world.py
+++ b/esper/world.py
@@ -1,7 +1,8 @@
+from functools import lru_cache, partial
 
 
 class World:
-    def __init__(self):
+    def __init__(self, cache_size=None):
         """A World object keeps track of all Entities, Components and Processors.
 
         A World contains a database of all Entity/Component assignments. It also
@@ -11,12 +12,18 @@ class World:
         self._next_entity_id = 0
         self._components = {}
         self._entities = {}
+        self.set_cache_size(cache_size)
+
+    def set_cache_size(self, size):
+        wrapped = self._get_entities.__wrapped__.__get__(self, World)
+        self._get_entities = lru_cache(size)(wrapped)
 
     def clear_database(self):
         """Remove all entities and components from the world."""
         self._components.clear()
         self._entities.clear()
         self._next_entity_id = 0
+        self._get_entities.cache_clear()
 
     def add_processor(self, processor_instance, priority=0):
         """Add a Processor instance to the world.
@@ -64,7 +71,8 @@ class World:
                 del self._components[component_type]
 
         try:
-            del self._entities[entity]
+            del self._entites[entity]
+            self._get_entities.cache_clear()
         except KeyError:
             pass
 
@@ -97,6 +105,7 @@ class World:
         if entity not in self._entities:
             self._entities[entity] = {}
         self._entities[entity][component_type] = component_instance
+        self._get_entities.cache_clear()
 
     def delete_component(self, entity, component_type):
         """Delete a Component instance from an Entity, by type.
@@ -110,6 +119,7 @@ class World:
         """
         try:
             self._components[component_type].discard(entity)
+            self._get_entities.cache_clear()
 
             if not self._components[component_type]:
                 del self._components[component_type]
@@ -134,6 +144,15 @@ class World:
         for entity in self._components.get(component_type, []):
             yield entity, entitydb[entity][component_type]
 
+    @lru_cache()
+    def _get_entities(self, component_types):
+        entities = self._components[component_types[0]]
+
+        for component_type in component_types[1:]:
+            entities &= self._components[component_type]
+
+        return entities
+
     def get_components(self, *component_types):
         """Get an iterator for entity and multiple Component sets.
 
@@ -141,13 +160,8 @@ class World:
         :return: An iterator for (Entity, Component1, Component2, etc)
         tuples.
         """
-        entities = self._components[component_types[0]]
         entitydb = self._entities
-
-        for component_type in component_types[1:]:
-            entities &= self._components[component_type]
-
-        for entity in entities:
+        for entity in self._get_entities(component_types):
             components = entitydb[entity]
             yield entity, [components[ct] for ct in component_types
                            if ct in components]

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,6 +1,11 @@
-import pickle
-import time
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import gc
+import pickle
+import sys
+import time
+
 import esper
 
 
@@ -20,7 +25,7 @@ def timing(f):
 ##############################
 #  Instantiate the game world:
 ##############################
-world = esper.World()
+world = esper.CachedWorld() if '--use-cache' in sys.argv[1:] else esper.World()
 
 
 #################################


### PR DESCRIPTION
For the sake of completeness, here is a new PR with the cache re-added but disabled by default and a method to set the cache size.

In the current benchmark scenario it doesn't give any performance improvements with the cache on, since it is invalidated whenever the number of entities increases so it is used only 19 times. As you increase the number of iterations of for each world size (e.g. from 20 to 1000), its effects start to show a *tiny* bit.

I'm not sure it is worth it. Maybe wait until we have more real-word examples and see what kind of scenarios are the most common.