### PR TITLE
Add setuptools support and distribution meta data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Benchmark results
+*.pickle
+
+# Python byte code
+*.py[co]
+
+# C extensions
+*.so
+*.pyd
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.rst
+graft examples

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -1,9 +1,8 @@
 from .world import CachedWorld, World
 from .templates import Processor
 
-__version__ = "0.9.2"
-__author__ = "Benjamin Moran"
-__license__ = "MIT"
-__copyright__ = "Benjamin Moran"
+from .meta import (author as __author__, version as __version__,
+                   license as __license__)
+__copyright__ = __author__
 
 __all__ = ("CachedWorld", "Processor", "World")

--- a/esper/meta.py
+++ b/esper/meta.py
@@ -1,0 +1,36 @@
+# -*- coding:utf-8 -*-
+#
+# meta.py - release information for the esper distribution
+#
+"""Esper is a lightweight Entity System for Python, with a focus on performance.
+"""
+
+name = 'esper'
+version = '0.9.2'
+description = __doc__.splitlines()[0]
+keywords = 'ecs,entity component system'
+author = "Benjamin Moran"
+license = "MIT"
+#author_email = ''
+url = 'https://github.com/benmoran56/esper'
+download_url = url + '/releases'
+platforms = 'POSIX, Windows, MacOS X'
+classifiers = """\
+Development Status :: 4 - Beta
+Intended Audience :: Developers
+License :: OSI Approved :: MIT License
+Operating System :: OS Independent
+Programming Language :: Python
+Programming Language :: Python :: 3
+Programming Language :: Python :: 3.2
+Programming Language :: Python :: 3.3
+Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
+Topic :: Games/Entertainment
+Topic :: Software Development :: Libraries :: Python Modules
+"""
+classifiers = [c.strip() for c in classifiers.splitlines()
+    if c.strip() and not c.startswith('#')]
+try: # Python 2.x
+    del c
+except: pass

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+from setuptools import setup, find_packages
+
+
+# read meta-data from esper/meta.py
+setup_opts = {}
+meta_info = os.path.join('esper', 'meta.py')
+exec(compile(open(meta_info).read(), meta_info, 'exec'), {}, setup_opts)
+
+readme = open('README.rst').read()
+
+setup(
+    long_description=readme,
+    packages=find_packages(exclude=['docs']),
+    **setup_opts
+)


### PR DESCRIPTION
Implements #8.

Depends on #11.

I left out pure-distutils compatibility since I think setuptools is pretty omnipresent these days, but I can easily add if, if wanted.