### PR TITLE
Add optional components to `create_entity`

### DIFF
--- a/esper/world.py
+++ b/esper/world.py
@@ -59,13 +59,19 @@ class World:
             if type(processor) == processor_type:
                 return processor
 
-    def create_entity(self):
+    def create_entity(self, *components):
         """Create a new Entity.
 
         This method returns an Entity ID, which is just a plain integer.
+        :param components: Optional components to be added to the entity
+        on creation.
         :return: The next Entity ID in sequence.
         """
         self._next_entity_id += 1
+
+        for component in components:
+            self.add_component(self._next_entity_id, component)
+
         return self._next_entity_id
 
     def delete_entity(self, entity, immediate=False):

--- a/tests/test_cached_world.py
+++ b/tests/test_cached_world.py
@@ -30,6 +30,15 @@ def test_create_entity(world):
     assert entity1 < entity2
 
 
+def test_create_entity_with_components(world):
+    entity1 = world.create_entity(ComponentA())
+    entity2 = world.create_entity(ComponentB())
+    assert world.has_component(entity1, ComponentA) is True
+    assert world.has_component(entity1, ComponentB) is False
+    assert world.has_component(entity2, ComponentA) is False
+    assert world.has_component(entity2, ComponentB) is True
+
+
 def test_delete_entity(world):
     # TODO: handle case where entity has never been assigned components
     entity1 = world.create_entity()
@@ -80,10 +89,10 @@ def test_has_component(world):
     entity2 = world.create_entity()
     world.add_component(entity1, ComponentA())
     world.add_component(entity2, ComponentB())
-    assert world.has_component(entity1, ComponentA) == True
-    assert world.has_component(entity1, ComponentB) == False
-    assert world.has_component(entity2, ComponentA) == False
-    assert world.has_component(entity2, ComponentB) == True
+    assert world.has_component(entity1, ComponentA) is True
+    assert world.has_component(entity1, ComponentB) is False
+    assert world.has_component(entity2, ComponentA) is False
+    assert world.has_component(entity2, ComponentB) is True
 
 
 def test_get_two_components(populated_world):

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -30,6 +30,15 @@ def test_create_entity(world):
     assert entity1 < entity2
 
 
+def test_create_entity_with_components(world):
+    entity1 = world.create_entity(ComponentA())
+    entity2 = world.create_entity(ComponentB())
+    assert world.has_component(entity1, ComponentA) is True
+    assert world.has_component(entity1, ComponentB) is False
+    assert world.has_component(entity2, ComponentA) is False
+    assert world.has_component(entity2, ComponentB) is True
+
+
 def test_delete_entity(world):
     # TODO: handle case where entity has never been assigned components
     entity1 = world.create_entity()
@@ -72,10 +81,10 @@ def test_has_component(world):
     entity2 = world.create_entity()
     world.add_component(entity1, ComponentA())
     world.add_component(entity2, ComponentB())
-    assert world.has_component(entity1, ComponentA) == True
-    assert world.has_component(entity1, ComponentB) == False
-    assert world.has_component(entity2, ComponentA) == False
-    assert world.has_component(entity2, ComponentB) == True
+    assert world.has_component(entity1, ComponentA) is True
+    assert world.has_component(entity1, ComponentB) is False
+    assert world.has_component(entity2, ComponentA) is False
+    assert world.has_component(entity2, ComponentB) is True
 
 
 def test_get_component(populated_world):


### PR DESCRIPTION
Because of the common pattern of creating components at the same time as entity creation, I added a less verbose to include an optional list of components in the `create_entity` function.

The usage is optional and should be fully backward-compatible.

Before:
```python
player = world.create_entity()
world.add_component(player, Velocity(x=0.9, y=1.2))
world.add_component(player, Position(x=5, y=5))
world.add_component(player, Sprite(player_sprite))
```

After:
```python
player = world.create_entity(
    Velocity(x=0.9, y=1.2),
    Position(x=5, y=5),
    Sprite(player_sprite),
)
```