### PR TITLE
Utilize Cython to Increase Performance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,22 +10,26 @@ Esper
 **Esper is a lightweight Entity System for Python, with a focus on performance.**
 
 Esper is an MIT licensed Entity System, or, Entity Component System (ECS).
-The design is based on the Entity System concepts outlined by Adam Martin in his blog at
-http://t-machine.org/, and others. Efforts were made to keep it as lightweight and performant
-as possible.
+The design is based on the Entity System concepts outlined by Adam Martin in `his blog <http://t-machine.org/>`_
+and others. Efforts were made to keep it as lightweight and performant
+as possible, most notably through the use of Cython.
 
-There is a fairly accurate writeup describing Entity Systems in this Wikipedia article:
-https://en.wikipedia.org/wiki/Entity_component_system
+There is a fairly accurate writeup describing Entity Systems in this `Wikipedia <https://en.wikipedia.org/wiki/Entity_component_system>`_ article.
 
-API documentation is hosted at ReadTheDocs: https://esper.readthedocs.io
+API documentation is hosted at `ReadTheDocs <https://esper.readthedocs.io>`_.
 
-Inspired by Sean Fisk's **ecs** https://github.com/seanfisk/ecs,
-and Marcus von Appen's **ebs** https://bitbucket.org/marcusva/python-utils.
+Inspired by Sean Fisk's `ecs <https://github.com/seanfisk/ecs>`_,
+and Marcus von Appen's `ebs <https://bitbucket.org/marcusva/python-utils>`_.
 
 
 What's New
 ----------
-**1.2** - Calls to `super()` are no longer necessary in your Processor subclasses.
+**1.3.0** - Dramatic performance improvements by Cythonizing Esper and using the `fastcache <https://pypi.org/project/fastcache/>`_ library.
+            The usage of Cython increased performance by 22% and is evidenced in the "benchmark_fps.py"
+            example. In addition, cache hits were further improved by up to 10-30x by using the fastcache
+            library instead of the caching implementation found in functools.
+
+**1.2.0** - Calls to `super()` are no longer necessary in your Processor subclasses.
             This should eliminate a fair amount of boilerplate. The README has also been updated
             with more usage examples. All methods should now have at least one example. And finally,
             wheels are now uploaded to PyPi. This should help with packaging systems that only support

--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,9 @@ and Marcus von Appen's `ebs <https://bitbucket.org/marcusva/python-utils>`_.
 
 What's New
 ----------
-**1.3.1** - Dramatic performance improvements by Cythonizing Esper and using the `fastcache <https://pypi.org/project/fastcache/>`_ library.
+**1.3.1** - Dramatic performance improvements by Cythonizing Esper.
             The usage of Cython increased performance by 22% and is evidenced in the "benchmark_fps.py"
-            example. In addition, cache hits were further improved by up to 10-30x by using the fastcache
-            library instead of the caching implementation found in functools.
+            example. Cache sizes were also limited to allow for LRU optimization.
 
 **1.3.0** - Feature release.
             Added new `World.has_components` method which allows multiple Component queries. Returns a boolean.

--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,14 @@ and Marcus von Appen's `ebs <https://bitbucket.org/marcusva/python-utils>`_.
 
 What's New
 ----------
-**1.3.0** - Dramatic performance improvements by Cythonizing Esper and using the `fastcache <https://pypi.org/project/fastcache/>`_ library.
+**1.3.1** - Dramatic performance improvements by Cythonizing Esper and using the `fastcache <https://pypi.org/project/fastcache/>`_ library.
             The usage of Cython increased performance by 22% and is evidenced in the "benchmark_fps.py"
             example. In addition, cache hits were further improved by up to 10-30x by using the fastcache
             library instead of the caching implementation found in functools.
+
+**1.3.0** - Feature release.
+            Added new `World.has_components` method which allows multiple Component queries. Returns a boolean.
+            Added new `World.try_components` method which allows multiple Component queries.
 
 **1.2.0** - Calls to `super()` are no longer necessary in your Processor subclasses.
             This should eliminate a fair amount of boilerplate. The README has also been updated

--- a/esper.py
+++ b/esper.py
@@ -1,6 +1,6 @@
 import time as _time
 
-from functools import lru_cache as _lru_cache
+from fastcache import clru_cache as _lru_cache
 from typing import List as _List
 from typing import Type as _Type
 from typing import TypeVar as _TypeVar
@@ -13,6 +13,9 @@ version = '1.3'
 
 C = _TypeVar('C')
 P = _TypeVar('P')
+
+# NOTE: Limiting cache size allows taking advantage of LRU eviction capabilities
+MAX_CACHE_SIZE = 100_000
 
 
 class Processor:
@@ -267,11 +270,11 @@ class World:
         except KeyError:
             pass
 
-    @_lru_cache()
+    @_lru_cache(maxsize=MAX_CACHE_SIZE)
     def get_component(self, component_type: _Type[C]) -> _List[_Tuple[int, C]]:
         return [query for query in self._get_component(component_type)]
 
-    @_lru_cache()
+    @_lru_cache(maxsize=MAX_CACHE_SIZE)
     def get_components(self, *component_types: _Type):
         return [query for query in self._get_components(*component_types)]
 

--- a/esper.py
+++ b/esper.py
@@ -9,7 +9,7 @@ from typing import Tuple as _Tuple
 from typing import Iterable as _Iterable
 
 
-version = '1.3'
+version = '1.3.1'
 
 C = _TypeVar('C')
 P = _TypeVar('P')

--- a/esper.py
+++ b/esper.py
@@ -15,7 +15,7 @@ C = _TypeVar('C')
 P = _TypeVar('P')
 
 # NOTE: Limiting cache size allows taking advantage of LRU eviction capabilities
-MAX_CACHE_SIZE = 100_000
+MAX_CACHE_SIZE = 100000
 
 
 class Processor:

--- a/esper.py
+++ b/esper.py
@@ -1,6 +1,6 @@
 import time as _time
 
-from fastcache import clru_cache as _lru_cache
+from functools import lru_cache as _lru_cache
 from typing import List as _List
 from typing import Type as _Type
 from typing import TypeVar as _TypeVar

--- a/examples/benchmark_fps.py
+++ b/examples/benchmark_fps.py
@@ -1,0 +1,45 @@
+import math, time, esper
+
+CTM = lambda: round(time.time() * 1000)
+
+class Life:
+    def __init__(self):
+        self.cur_hp = 100
+        self.max_hp = 100
+
+    def breathe(self):
+        pass
+
+class Breathe(esper.Processor):
+    def process(self):
+        for ent, (life,) in self.world.get_components(Life):
+            life.breathe()
+
+world = esper.World()
+world.add_processor(Breathe())
+
+TARGET_FPS = 60
+NUM_ENTITIES = 19900
+entities = []
+for i in range(NUM_ENTITIES):
+    entities.append(world.create_entity(Life()))
+
+avg = []
+try:
+    while True:
+        fps = 0
+        start = CTM()
+        while CTM() < start + 1000:
+            world.process()
+            fps += 1
+        print(f'FPS with {len(entities)} entities:', fps)
+        avg.append((fps, len(entities)))
+        # if fps > TARGET_FPS:
+        #     for i in range(3):#math.ceil(fps / TARGET_FPS) - 1 + TARGET_FPS):
+        #         entities.append(world.create_entity(Life()))
+except KeyboardInterrupt:
+    avg_fps = [fps for (fps, _) in avg]
+    avg_fps = sum(avg_fps) / len(avg_fps)
+    avg_ent = [ent for (_, ent) in avg]
+    avg_ent = sum(avg_ent) / len(avg_ent)
+    print(f'Had an average FPS of {avg_fps} with an average of {avg_ent} entities')

--- a/examples/benchmark_fps.py
+++ b/examples/benchmark_fps.py
@@ -46,7 +46,7 @@ try:
         while CTM() < start + 1000:
             world.process()
             fps += 1
-        print(f'FPS with {len(entities)} entities:', fps)
+        print('FPS with', len(entities), 'entities:', fps)
         avg.append((fps, len(entities)))
 
         # WHITTLE down FPS gradually to reach target fps
@@ -61,4 +61,4 @@ except KeyboardInterrupt:
     avg_fps = sum(avg_fps) / len(avg_fps)
     avg_ent = [ent for (_, ent) in avg]
     avg_ent = sum(avg_ent) / len(avg_ent)
-    print(f'Had an average FPS of {avg_fps} with an average of {avg_ent} entities')
+    print('Had an average FPS of', avg_fps, 'with an average of', avg_ent, 'entities')

--- a/examples/benchmark_fps.py
+++ b/examples/benchmark_fps.py
@@ -37,7 +37,7 @@ for i in range(NUM_ENTITIES):
     entities.append(world.create_entity(Life()))
 
 avg = []
-WHITTLE = False  # Choose whether to try to get town to target fps during test
+WHITTLE = False  # Choose whether to try to get down to target fps during test
 RUN_CONTINUOUSLY = False
 try:
     for _ in range(60):  # One minute

--- a/examples/benchmark_fps.py
+++ b/examples/benchmark_fps.py
@@ -1,3 +1,15 @@
+"""
+This benchmark is designed to test how many entities a world can process in the
+span of one second (frames per second). This metric is used to determine at what
+point that Esper is no longer able to process all entities each frame (takes
+longer than one frames time to process).
+
+Configuration: You can adjust NUM_ENTITIES to be whatever number you want to see
+how fast Esper is on your system. If you are on a fast computer and Esper is
+processing faster than TARGET_FPS, you can set WHITTLE to True, which will tell
+the benchmark to try to add more entities until fps == TARGET_FPS.
+"""
+
 import math, time, esper
 
 CTM = lambda: round(time.time() * 1000)
@@ -19,14 +31,16 @@ world = esper.World()
 world.add_processor(Breathe())
 
 TARGET_FPS = 60
-NUM_ENTITIES = 19900
+NUM_ENTITIES = 25700#19900
 entities = []
 for i in range(NUM_ENTITIES):
     entities.append(world.create_entity(Life()))
 
 avg = []
+WHITTLE = False  # Choose whether to try to get town to target fps during test
+RUN_CONTINUOUSLY = False
 try:
-    while True:
+    for _ in range(60):  # One minute
         fps = 0
         start = CTM()
         while CTM() < start + 1000:
@@ -34,9 +48,14 @@ try:
             fps += 1
         print(f'FPS with {len(entities)} entities:', fps)
         avg.append((fps, len(entities)))
-        # if fps > TARGET_FPS:
-        #     for i in range(3):#math.ceil(fps / TARGET_FPS) - 1 + TARGET_FPS):
-        #         entities.append(world.create_entity(Life()))
+
+        # WHITTLE down FPS gradually to reach target fps
+        if WHITTLE:
+            if fps > TARGET_FPS:
+                for i in range(100):#math.ceil(fps / TARGET_FPS) - 1 + TARGET_FPS):
+                    entities.append(world.create_entity(Life()))
+    if not RUN_CONTINUOUSLY:
+        raise KeyboardInterrupt()
 except KeyboardInterrupt:
     avg_fps = [fps for (fps, _) in avg]
     avg_fps = sum(avg_fps) / len(avg_fps)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cython>=0.29.14
+fastcache>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 cython>=0.29.14
-fastcache>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+from Cython.Build import cythonize
 
 
 with open('esper.py') as f:
@@ -10,22 +11,27 @@ with open('esper.py') as f:
 
 README = open('README.rst').read()
 
-setup(name='esper',
-      version=info['version'],
-      author='Benjamin Moran',
-      author_email='benmoran@protonmail.com',
-      description="esper is a lightweight Entity System (ECS) for Python, with a focus on performance.",
-      long_description=README,
-      license='MIT',
-      keywords='ecs,entity component system,game',
-      url='https://github.com/benmoran56/esper',
-      download_url='https://github.com/benmoran56/esper/releases',
-      platforms='POSIX, Windows, MacOS X',
-      py_modules=['esper'],
-      classifiers=["Development Status :: 5 - Production/Stable",
-                   "Intended Audience :: Developers",
-                   "License :: OSI Approved :: MIT License",
-                   "Operating System :: OS Independent",
-                   "Programming Language :: Python :: 3 :: Only",
-                   "Topic :: Games/Entertainment",
-                   "Topic :: Software Development :: Libraries"])
+setup(
+    name='esper',
+    version=info['version'],
+    author='Benjamin Moran',
+    author_email='benmoran@protonmail.com',
+    description="esper is a lightweight Entity System (ECS) for Python, with a focus on performance.",
+    long_description=README,
+    license='MIT',
+    keywords='ecs,entity component system,game',
+    url='https://github.com/benmoran56/esper',
+    download_url='https://github.com/benmoran56/esper/releases',
+    platforms='POSIX, Windows, MacOS X',
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Games/Entertainment",
+        "Topic :: Software Development :: Libraries"
+    ],
+    py_modules=['esper'],
+    #ext_modules=cythonize('esper.py')
+)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "Topic :: Games/Entertainment",
         "Topic :: Software Development :: Libraries"
     ],
-    #py_modules=['esper'],
     ext_modules=cythonize('esper.py'),
     install_requires=['cython>=0.29.14', 'fastcache>=1.1.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Topic :: Games/Entertainment",
         "Topic :: Software Development :: Libraries"
     ],
-    py_modules=['esper'],
-    #ext_modules=cythonize('esper.py')
+    #py_modules=['esper'],
+    ext_modules=cythonize('esper.py'),
+    install_requires=['cython>=0.29.14', 'fastcache>=1.1.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
         "Topic :: Software Development :: Libraries"
     ],
     ext_modules=cythonize('esper.py'),
-    install_requires=['cython>=0.29.14', 'fastcache>=1.1.0']
+    install_requires=['cython>=0.29.14']
 )


### PR DESCRIPTION
Fix #41 

## Summary of Changes

* **Improved performance by 22%** by using Cython to compile the project
* Added new `benchmark_fps.py` example to measure FPS performance which is similar to games.
* Readme was updated to reflect the necessary version increase due to reliance upon user having C compiler installed. Also described changes and placed a focus on Cython compilation as a feature.

> Note: Making Cython a dependency has the potential downside of forcing the user to install a C compiler, which can be tricky on platforms such as Windows. However, most Python users make use of the Numpy library, which uses Cython, so they should already have a compiler toolchain installed, meaning impact should be minimal. One way to mitigate any negative effects of this is to create a `bdist_wheel` for all major platforms in a CI/CD pipeline.

> Note: the "Cython" topic should be added to the Esper repo to encourage seekers of high-performance Python code to check out Esper! :)