### PR TITLE
added optional class alias for Components

### DIFF
--- a/esper.py
+++ b/esper.py
@@ -203,7 +203,7 @@ class World:
         """
         return all(comp_type in self._entities[entity] for comp_type in component_types)
 
-    def add_component(self, entity: int, component_instance: _Any) -> None:
+    def add_component(self, entity: int, component_instance: _Any, alias: _Any = None) -> None:
         """Add a new Component instance to an Entity.
 
         Add a Component instance to an Entiy. If a Component of the same type
@@ -212,7 +212,7 @@ class World:
         :param entity: The Entity to associate the Component with.
         :param component_instance: A Component instance.
         """
-        component_type = type(component_instance)
+        component_type = type(alias) if alias else type(component_instance)
 
         if component_type not in self._components:
             self._components[component_type] = set()

--- a/esper.py
+++ b/esper.py
@@ -203,7 +203,7 @@ class World:
         """
         return all(comp_type in self._entities[entity] for comp_type in component_types)
 
-    def add_component(self, entity: int, component_instance: _Any, alias: _Any = None) -> None:
+    def add_component(self, entity: int, component_instance: _Any, type_alias: _Type = None) -> None:
         """Add a new Component instance to an Entity.
 
         Add a Component instance to an Entiy. If a Component of the same type
@@ -212,7 +212,7 @@ class World:
         :param entity: The Entity to associate the Component with.
         :param component_instance: A Component instance.
         """
-        component_type = type(alias) if alias else type(component_instance)
+        component_type = type_alias or type(component_instance)
 
         if component_type not in self._components:
             self._components[component_type] = set()

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -47,6 +47,12 @@ def test_create_entity_and_add_components(world):
     assert world.has_component(entity1, ComponentA) is True
     assert world.has_component(entity1, ComponentC) is False
 
+def test_create_entity_and_add_components_with_alias(world):
+    entity = world.create_entity()
+    world.add_component(entity, ComponentA(), alias=ComponentF())
+    assert world.has_component(entity, ComponentF) is True
+    assert world.component_for_entity(entity, ComponentF).a == -66
+
 
 def test_delete_entity(world):
     entity1 = world.create_entity()
@@ -312,6 +318,11 @@ class ComponentE:
     def __init__(self):
         self.items = {"itema": None, "itemb": 1000}
         self.points = [a + 2 for a in list(range(44))]
+
+
+class ComponentF:
+    def __init__(self):
+        pass
 
 
 class CorrectProcessorA(esper.Processor):

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -49,7 +49,7 @@ def test_create_entity_and_add_components(world):
 
 def test_create_entity_and_add_components_with_alias(world):
     entity = world.create_entity()
-    world.add_component(entity, ComponentA(), alias=ComponentF())
+    world.add_component(entity, ComponentA(), type_alias=ComponentF)
     assert world.has_component(entity, ComponentF) is True
     assert world.component_for_entity(entity, ComponentF).a == -66
 


### PR DESCRIPTION
This change allowed me to conveniently use components which solely contained an object from a third party library. For example, I could have a velocity and position component that just contain one variable for a pygame.Vector2().

Without aliasing, the processor would be
```python
for ent, (vel, pos) in world.get_components(Velocity, Position):
    pos.position += vel.velocity
```
many of my processors have even more clutter, since I have many components that have just one numpy array or vector, but this is the simplest example.

With aliasing, we can do:
```python
world.add_component(entity, pygame.Vector2(0, 0), alias=Velocity())
world.add_component(entity, pygame.Vector2(10, 10), alias=Position())
```
```python
for ent, (vel, pos) in world.get_components(Velocity, Position):
    pos += vel
```

I know simplicity and performance is of high importance for this project, so I'd love to know if esper would or would not benefit from these changes!