### PR TITLE
Expose @component decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,15 @@ code, but no processing logic whatsoever. A simple Component might look like::
             self.x = x
             self.y = y
 
+Esper exports Python's *dataclasses.dataclass*
+(https://docs.python.org/3/library/dataclasses.html#module-dataclasses) decorator as
+*esper.component*, which can be used to reduce boilerplate::
+
+    @component
+    class Position:
+        x: float = 0.0
+        y: float = 0.0
+
 
 * Processors
 

--- a/esper.py
+++ b/esper.py
@@ -1,5 +1,7 @@
 import time as _time
 
+from dataclasses import dataclass as component
+
 from functools import lru_cache as _lru_cache
 
 from typing import Any as _Any

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -7,7 +7,7 @@ import sys
 import time
 import optparse
 
-import esper
+from esper import component, World
 
 ######################
 # Commandline options:
@@ -50,49 +50,49 @@ def timing(f):
 ##############################
 #  Instantiate the game world:
 ##############################
-world = esper.World()
+world = World()
 
 
 #################################
 # Define some generic components:
 #################################
+@component
 class Velocity:
-    def __init__(self):
-        self.x = 0
-        self.y = 0
+    x: int = 0
+    y: int = 0
 
 
+@component
 class Position:
-    def __init__(self):
-        self.x = 0
-        self.y = 0
+    x: int = 0
+    y: int = 0
 
 
+@component
 class Health:
-    def __init__(self):
-        self.hp = 100
+    hp: int = 100
 
 
+@component
 class Command:
-    def __init__(self):
-        self.attack = False
-        self.defend = True
+    attack: bool = False
+    defend: bool = True
 
 
+@component
 class Projectile:
-    def __init__(self):
-        self.size = 10
-        self.lifespan = 100
+    size: int = 10
+    lifespan: int = 100
 
 
+@component
 class Damageable:
-    def __init__(self):
-        self.defense = 45
+    defense: int = 45
 
 
+@component
 class Brain:
-    def __init__(self):
-        self.smarts = 9000
+    smarts: int = 9000
 
 
 #############################

--- a/examples/benchmark_cache.py
+++ b/examples/benchmark_cache.py
@@ -4,7 +4,7 @@
 import sys
 import time
 import optparse
-import esper
+from esper import component, Processor, World
 
 try:
     from matplotlib import pyplot
@@ -43,55 +43,55 @@ def timing(f):
 ##########################
 # Create a World instance:
 ##########################
-world = esper.World()
+world = World()
 
 
 #################################
 # Define some generic components:
 #################################
+@component
 class Velocity:
-    def __init__(self, x=0.0, y=0.0):
-        self.x = x
-        self.y = y
+    x: float = 0.0
+    y: float = 0.0
 
 
+@component
 class Position:
-    def __init__(self, x=0.0, y=0.0):
-        self.x = x
-        self.y = y
+    x: float = 0.0
+    y: float = 0.0
 
 
+@component
 class Health:
-    def __init__(self):
-        self.hp = 100
+    hp: int = 100
 
 
+@component
 class Command:
-    def __init__(self):
-        self.attack = False
-        self.defend = True
+    attack: bool = False
+    defend: bool = True
 
 
+@component
 class Projectile:
-    def __init__(self):
-        self.size = 10
-        self.lifespan = 100
+    size: int = 10
+    lifespan: int = 100
 
 
+@component
 class Damageable:
-    def __init__(self):
-        self.defense = 45
+    defense: int = 45
 
 
+@component
 class Brain:
-    def __init__(self):
-        self.smarts = 9000
+    smarts: int = 9000
 
 
 ##########################
 #  Define some Processors:
 ##########################
-class MovementProcessor(esper.Processor):
+class MovementProcessor(Processor):
     def __init__(self):
         super().__init__()
 

--- a/examples/headless_example.py
+++ b/examples/headless_example.py
@@ -1,26 +1,26 @@
-import esper
 import time
+from esper import component, Processor, World
 
 
 ##################################
 #  Define some Components:
 ##################################
+@component
 class Velocity:
-    def __init__(self, x=0.0, y=0.0):
-        self.x = x
-        self.y = y
+    x: float = 0.0
+    y: float = 0.0
 
 
+@component
 class Position:
-    def __init__(self, x=0, y=0):
-        self.x = x
-        self.y = y
+    x: int = 0
+    y: int = 0
 
 
 ################################
 #  Define some Processors:
 ################################
-class MovementProcessor(esper.Processor):
+class MovementProcessor(Processor):
     def __init__(self):
         super().__init__()
 
@@ -36,7 +36,7 @@ class MovementProcessor(esper.Processor):
 ##########################################################
 def main():
     # Create a World instance to hold everything:
-    world = esper.World()
+    world = World()
 
     # Instantiate a Processor (or more), and add them to the world:
     movement_processor = MovementProcessor()


### PR DESCRIPTION
While playing around with esper I noticed that making components involved a bit of boilerplate:
```python
class Position:
    def __init__(self, x=0.0, y=0.0, z=0.0):
        self.x = x
        self.y = y
        self.z = z
```
I solved this by using Python's `dataclasses.dataclass` decorator, imported as `component`:
```python
@component
class Position:
    x: float = 0.0
    y: float = 0.0
    z: float = 0.0
```
I thought this looked a bit nicer, so here's a patch that exposes this as `esper.component`, adds a note in the readme, and updates some examples to use it.