### PR TITLE
Change try_components methods in order to not return an iterable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,9 +310,10 @@ write it this way::
         stun.duration -= dt
 
 The above code works fine, but the *try_component* method is more concise and slightly faster. 
-It allows you to get specific Components only if they exist, but passes silently if they do not::
+It allows you to get specific Components only if they exist, but returns None if they do not::
 
-    for stun in self.world.try_component(ent, Stun):
+    stun = self.world.try_component(ent, Stun)
+    if stun:
         stun.duration -= dt
 
 

--- a/esper.py
+++ b/esper.py
@@ -297,25 +297,24 @@ class World:
     def get_components(self, *component_types: _Type[_C]) -> _List[_Tuple[int, _List[_C]]]:
         return [query for query in self._get_components(*component_types)]
 
-    def try_component(self, entity: int, component_type: _Type[_C]) -> _Optional[_Iterable[_C]]:
+    def try_component(self, entity: int, component_type: _Type[_C]) -> _Optional[_C]:
         """Try to get a single component type for an Entity.
 
         This method will return the requested Component if it exists, but
         will pass silently if it does not. This allows a way to access
         optional Components that may or may not exist, without having to
-        first querty the Entity to see if it has the Component type.
+        first query the Entity to see if it has the Component type.
 
         :param entity: The Entity ID to retrieve the Component for.
         :param component_type: The Component instance you wish to retrieve.
-        :return: A iterator containg the single Component instance requested,
-                 which is empty if the component doesn't exist.
+        :return: the single Component instance requested, which is None if the component doesn't exist.
         """
         if component_type in self._entities[entity]:
-            yield self._entities[entity][component_type]
+            return self._entities[entity][component_type]
         else:
             return None
 
-    def try_components(self, entity: int, *component_types: _Type[_C]) -> _Optional[_Iterable[_List[_C]]]:
+    def try_components(self, entity: int, *component_types: _Type[_C]) -> _Optional[_List[_List[_C]]]:
         """Try to get a multiple component types for an Entity.
 
         This method will return the requested Components if they exist, but
@@ -325,11 +324,10 @@ class World:
 
         :param entity: The Entity ID to retrieve the Component for.
         :param component_types: The Components types you wish to retrieve.
-        :return: A iterator containg the multiple Component instances requested,
-                 which is empty if the components do not exist.
+        :return: A List containing the multiple Component instances requested, which is empty if the components do not exist.
         """
         if all(comp_type in self._entities[entity] for comp_type in component_types):
-            yield [self._entities[entity][comp_type] for comp_type in component_types]
+            return [self._entities[entity][comp_type] for comp_type in component_types]
         else:
             return None
 

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -1,7 +1,6 @@
-import types
+import pytest
 
 import esper
-import pytest
 
 
 @pytest.fixture
@@ -46,6 +45,7 @@ def test_create_entity_and_add_components(world):
     world.add_component(entity1, ComponentB())
     assert world.has_component(entity1, ComponentA) is True
     assert world.has_component(entity1, ComponentC) is False
+
 
 def test_create_entity_and_add_components_with_alias(world):
     entity = world.create_entity()
@@ -160,25 +160,24 @@ def test_get_three_components(populated_world):
 def test_try_component(world):
     entity1 = world.create_entity(ComponentA(), ComponentB())
 
-    one_item_generator = world.try_component(entity=entity1, component_type=ComponentA)
-    assert type(one_item_generator) is types.GeneratorType
-    assert len(list(one_item_generator)) == 1
+    one_item = world.try_component(entity=entity1, component_type=ComponentA)
+    assert isinstance(one_item, ComponentA)
 
-    zero_item_generator = world.try_component(entity=entity1, component_type=ComponentC)
-    assert type(zero_item_generator) is types.GeneratorType
-    assert len(list(zero_item_generator)) == 0
+    zero_item = world.try_component(entity=entity1, component_type=ComponentC)
+    assert zero_item is None
 
 
 def test_try_components(world):
     entity1 = world.create_entity(ComponentA(), ComponentB())
 
-    one_item_generator = world.try_components(entity1, ComponentA, ComponentB)
-    assert isinstance(one_item_generator, types.GeneratorType)
-    assert len(list(one_item_generator)) == 1
+    one_item = world.try_components(entity1, ComponentA, ComponentB)
+    assert isinstance(one_item, list)
+    assert len(one_item) == 2
+    assert isinstance(one_item[0], ComponentA)
+    assert isinstance(one_item[1], ComponentB)
 
-    zero_item_generator = world.try_components(entity1, ComponentA, ComponentC)
-    assert isinstance(zero_item_generator, types.GeneratorType)
-    assert len(list(zero_item_generator)) == 0
+    zero_item = world.try_components(entity1, ComponentA, ComponentC)
+    assert zero_item is None
 
 
 def test_clear_database(populated_world):


### PR DESCRIPTION
Hey,

Here is a proposition for the *try_component(s)* methods. I don't understand why they are supposed to return an iterable since there are specifically designed to return a single component (or a list of single components for the *try_components* method).

I find it clearer to return either the Component(s) either None if they are not existing. You have an extra "if" compared to the iterator method but I think it is more readable.

Let me know what you think of this!