### PR TITLE
Change default first entity ID to 1

### DIFF
--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -42,7 +42,7 @@ class World:
     """
     def __init__(self, timed=False):
         self._processors = []
-        self._next_entity_id = 0
+        self._next_entity_id = 1
         self._components = {}
         self._entities = {}
         self._dead_entities = set()
@@ -58,7 +58,7 @@ class World:
 
     def clear_database(self) -> None:
         """Remove all Entities and Components from the World."""
-        self._next_entity_id = 0
+        self._next_entity_id = 1
         self._dead_entities.clear()
         self._components.clear()
         self._entities.clear()


### PR DESCRIPTION
Prior to this change, to have a value that stores a component ID set to a non-value, we must either:
- Use None, which complicates type definitions
- Use -1, which makes conditional tests ugly
- Reserve a throw-away entity ID 0

This change makes it so that we can use the naturally falsy 0 value for unset IDs.