### PR TITLE
Code style (PEP8 and more)

### DIFF
--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -117,6 +117,7 @@ class World:
     is also responsible for executing all Processors assigned to it for each
     frame of your game.
     """
+
     def __init__(self, timed=False):
         self._processors = []
         self._next_entity_id = 0

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -237,9 +237,9 @@ class World:
             self._dead_entities.add(entity)
 
     def entity_exists(self, entity: int) -> bool:
-        """Check if a specific entity exists.
+        """Check if a specific Entity exists.
 
-        Empty entities(with no components) and dead entities(destroyed
+        Empty Entities (with no components) and dead Entities (destroyed
         by delete_entity) will not count as existent ones.
         """
         return entity in self._entities and entity not in self._dead_entities

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -164,7 +164,7 @@ class World:
                itself, not the instance.
         """
         for processor in self._processors:
-            if type(processor) == processor_type:
+            if type(processor) is processor_type:
                 processor.world = None
                 self._processors.remove(processor)
 
@@ -176,7 +176,7 @@ class World:
         Processor, from within another Processor.
         """
         for processor in self._processors:
-            if type(processor) == processor_type:
+            if type(processor) is processor_type:
                 return processor
         else:
             return None


### PR DESCRIPTION
Conformed code to existing guidelines, in particular:
 * line length, suggested by PEP8 (79 max)
 * empty line after class docstrings, suggested by PEP257

Moreover, identity operator `is` is now used instead of equality comparison `==` for type checks (used in `remove_processor`, `get_processor`). When comparing types, this is semantically equivalent and should be generally faster.