### PR TITLE
FIX: removing last component deletes entity as well

### DIFF
--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -332,25 +332,13 @@ class World:
         Raises a KeyError if either the given entity or Component type does
         not exist in the database.
         """
-        if not _inspect.isclass(component_type):
-            raise TypeError("Provided component type is not a class")
-
-        if entity not in self._entities:
-            raise KeyError("Entity does not exist")
-
-        if (
-            component_type not in self._components
-            or component_type not in self._entities[entity]
-        ):
-            raise KeyError("Component does not exist")
-
         self._components[component_type].discard(entity)
 
         if not self._components[component_type]:
             del self._components[component_type]
 
         self.clear_cache()
-        return _cast(_C, self._entities[entity].pop(component_type))
+        return self._entities[entity].pop(component_type)
 
     def _get_component(self, component_type: _Type[_C]) -> _Iterable[_Tuple[int, _C]]:
         entity_db = self._entities

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -3,6 +3,7 @@ import time as _time
 
 from types import MethodType as _MethodType
 
+from typing import cast as _cast
 from typing import Iterable as _Iterable
 from typing import List as _List
 from typing import Optional as _Optional
@@ -321,7 +322,7 @@ class World:
         self._entities[entity][component_type] = component_instance
         self.clear_cache()
 
-    def remove_component(self, entity: int, component_type: _Type[_C]) -> int:
+    def remove_component(self, entity: int, component_type: _Type[_C]) -> _C:
         """Remove a Component instance from an Entity, by type.
 
         A Component instance can only be removed by providing its type.
@@ -349,7 +350,7 @@ class World:
             del self._components[component_type]
 
         self.clear_cache()
-        return self._entities[entity].pop(component_type)
+        return _cast(_C, self._entities[entity].pop(component_type))
 
     def _get_component(self, component_type: _Type[_C]) -> _Iterable[_Tuple[int, _C]]:
         entity_db = self._entities

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -280,12 +280,12 @@ class TestRemoveComponent:
         with pytest.raises(KeyError):
             world.remove_component(entity, ComponentA)
 
-    def test_remove_component_with_object_raises_type_error(self, populated_world):
+    def test_remove_component_with_object_raises_key_error(self, populated_world):
         entity = 2
         component = ComponentD()
 
         assert populated_world.has_component(entity, type(component))
-        with pytest.raises(TypeError):
+        with pytest.raises(KeyError):
             populated_world.remove_component(entity, component)
 
     def test_remove_component_returns_removed_instance(self, world):

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -269,6 +269,55 @@ def test_entity_exists(world):
     assert not world.entity_exists(future_entity)
 
 
+class TestRemoveComponent:
+    def test_remove_from_not_existing_entity_raises_key_error(self, world):
+        with pytest.raises(KeyError):
+            world.remove_component(123, ComponentA)
+
+    def test_remove_not_existing_component_raises_key_error(self, world):
+        entity = world.create_entity(ComponentB())
+
+        with pytest.raises(KeyError):
+            world.remove_component(entity, ComponentA)
+
+    def test_remove_component_with_object_raises_type_error(self, populated_world):
+        entity = 2
+        component = ComponentD()
+
+        assert populated_world.has_component(entity, type(component))
+        with pytest.raises(TypeError):
+            populated_world.remove_component(entity, component)
+
+    def test_remove_component_returns_removed_instance(self, world):
+        component = ComponentA()
+        entity = world.create_entity(component)
+
+        result = world.remove_component(entity, type(component))
+
+        assert result is component
+
+    def test_remove_last_component_leaves_empty_entity(self, world):
+        entity = world.create_entity()
+        world.add_component(entity, ComponentA())
+
+        world.remove_component(entity, ComponentA)
+
+        assert not world.has_component(entity, ComponentA)
+        assert world.entity_exists(entity)
+
+    def test_removing_one_component_leaves_other_intact(self, world):
+        component_a = ComponentA()
+        component_b = ComponentB()
+        component_c = ComponentC()
+        entity = world.create_entity(component_a, component_b, component_c)
+
+        world.remove_component(entity, ComponentB)
+
+        assert world.component_for_entity(entity, ComponentA) is component_a
+        assert not world.has_component(entity, ComponentB)
+        assert world.component_for_entity(entity, ComponentC) is component_c
+
+
 def test_event_dispatch_no_handlers():
     esper.dispatch_event("foo")
     esper.dispatch_event("foo", 1)


### PR DESCRIPTION
fixes #82

Due to boy scout rule, there are additional minor changes:
- add more explicit exceptions
- change return to removed component instead of entity