### PR TITLE
mypy --strict

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,15 @@
+[mypy]
+warn_unused_configs = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+strict_equality = True
+strict_concatenate = True

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -4,7 +4,6 @@ from types import MethodType as _MethodType
 
 from typing import Any as _Any
 from typing import Callable as _Callable
-from typing import cast as _cast
 from typing import Dict as _Dict
 from typing import List as _List
 from typing import Set as _Set
@@ -274,7 +273,7 @@ class World:
 
         Raises a KeyError if the given Entity and Component do not exist.
         """
-        return _cast(_C, self._entities[entity][component_type])
+        return self._entities[entity][component_type]  # type: ignore[no-any-return]
 
     def components_for_entity(self, entity: int) -> _Tuple[_C, ...]:
         """Retrieve all Components for a specific Entity, as a Tuple.
@@ -333,7 +332,7 @@ class World:
             del self._components[component_type]
 
         self.clear_cache()
-        return _cast(_C, self._entities[entity].pop(component_type))
+        return self._entities[entity].pop(component_type)  # type: ignore[no-any-return]
 
     def _get_component(self, component_type: _Type[_C]) -> _Iterable[_Tuple[int, _C]]:
         entity_db = self._entities
@@ -390,7 +389,7 @@ class World:
         has the Component type.
         """
         if component_type in self._entities[entity]:
-            return _cast(_C, self._entities[entity][component_type])
+            return self._entities[entity][component_type]  # type: ignore[no-any-return]
         return None
 
     def try_components(self, entity: int, *component_types: _Type[_C]) -> _Optional[_List[_List[_C]]]:

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -4,6 +4,7 @@ from types import MethodType as _MethodType
 
 from typing import Any as _Any
 from typing import Callable as _Callable
+from typing import cast as _cast
 from typing import Dict as _Dict
 from typing import List as _List
 from typing import Set as _Set
@@ -273,7 +274,7 @@ class World:
 
         Raises a KeyError if the given Entity and Component do not exist.
         """
-        return self._entities[entity][component_type]  # type: ignore
+        return _cast(_C, self._entities[entity][component_type])
 
     def components_for_entity(self, entity: int) -> _Tuple[_C, ...]:
         """Retrieve all Components for a specific Entity, as a Tuple.
@@ -332,7 +333,7 @@ class World:
             del self._components[component_type]
 
         self.clear_cache()
-        return self._entities[entity].pop(component_type)  # type: ignore
+        return _cast(_C, self._entities[entity].pop(component_type))
 
     def _get_component(self, component_type: _Type[_C]) -> _Iterable[_Tuple[int, _C]]:
         entity_db = self._entities
@@ -389,7 +390,7 @@ class World:
         has the Component type.
         """
         if component_type in self._entities[entity]:
-            return self._entities[entity][component_type]  # type: ignore
+            return _cast(_C, self._entities[entity][component_type])
         return None
 
     def try_components(self, entity: int, *component_types: _Type[_C]) -> _Optional[_List[_List[_C]]]:


### PR DESCRIPTION
mypy config dotfile with strict=True
full typing of esper/_init__.py
World(timed=True) become TimedWorld()
3 lines uses `# type : ignore` to disable type check on the line