### PR TITLE
Major Performance Optimizations (Fixes #115)

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,16 @@
+esper 3.5
+=========
+Performance-focused release with major internal optimizations.
+
+Changes
+-------
+- Optimized `get_components` to iterate over the smallest set of entities, drastically speeding up queries with rare components.
+- Implemented lazy cache invalidation to reduce overhead from frequent entity modifications.
+- Sped up `get_processor` and `remove_processor` to be constant time (O(1)) operations.
+- Minor performance improvements to entity creation and deletion routines.
+- Expanded Benchmarks.
+
+
 esper 3.4
 =========
 Maintenance release

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -373,7 +373,7 @@ def remove_component(entity: int, component_type: _Type[_C]) -> _C:
         del _components[component_type]
 
     clear_cache()
-    return _entities[entity].pop(component_type)
+    return _entities[entity].pop(component_type)  # type: ignore[no-any-return]
 
 
 def _get_component(component_type: _Type[_C]) -> _Iterable[_Tuple[int, _C]]:

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -21,6 +21,8 @@ from typing import overload as _overload
 from weakref import ref as _ref
 from weakref import WeakMethod as _WeakMethod
 
+from math import inf as _inf
+
 from itertools import count as _count
 
 __version__ = version = '3.5'
@@ -393,7 +395,7 @@ def _get_components(*component_types: _Type[_C]) -> _Iterable[_Tuple[int, _Tuple
     comp_db = _components
 
     min_set = None
-    min_size = float('inf')
+    min_size = _inf
     other_types = []
     
     for ct in component_types:

--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -484,7 +484,7 @@ def try_component(entity: int, component_type: _Type[_C]) -> _Optional[_C]:
     """
     entity_comps = _entities.get(entity)
     if entity_comps and component_type in entity_comps:
-        return entity_comps[component_type]
+        return entity_comps[component_type]  # type: ignore[no-any-return]
     return None
 
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import gc
+import random
 import sys
 import time
 import optparse
@@ -90,6 +91,11 @@ class Brain:
     smarts: int = 9000
 
 
+@component
+class IsPlayer:
+    pass
+
+
 #############################
 # Set up some dummy entities:
 #############################
@@ -97,6 +103,14 @@ def create_entities(number):
     for _ in range(number // 2):
         esper.create_entity(Position(), Velocity(), Health(), Command())
         esper.create_entity(Position(), Health(), Damageable())
+
+
+def create_mixed_entities(number):
+    for _ in range(number - 5):
+        esper.create_entity(Position(), Velocity())
+
+    for _ in range(5):
+        esper.create_entity(Position(), Velocity(), IsPlayer())
 
 
 #############################
@@ -120,10 +134,56 @@ def three_comp_query():
         pass
 
 
+@timing
+def rare_comp_query():
+    """
+    Benchmark a query involving a common and a rare component.
+
+    This scenario is designed to highlight the performance gain from the
+    "iterate over the smallest set" optimization. The query for
+    (Position, Velocity, IsPlayer) should be extremely fast, as it only
+    needs to iterate over the few entities that have the rare `IsPlayer`
+    component, instead of all entities with `Position`.
+    """
+    for _, (_, _, _) in esper.get_components(Position, Velocity, IsPlayer):
+        pass
+
+
+@timing
+def dynamic_world_frame(entities_to_kill, new_entities_to_create):
+    """
+    Benchmark a single frame in a dynamic world with entity churn.
+
+    This function simulates a typical game loop frame to measure performance
+    under dynamic conditions. It tests the combined cost of:
+    1. Running common queries.
+    2. Deleting a batch of existing entities (testing `delete_entity`).
+    3. Creating a batch of new entities (testing `create_entity`).
+    4. Cleaning up dead entities (testing `clear_dead_entities`).
+
+    This is a good test for the lazy cache invalidation and optimized
+    entity cleanup mechanisms.
+    """
+    for _, (_, _) in esper.get_components(Position, Velocity):
+        pass
+    for _, (_, _, _) in esper.get_components(Position, Damageable, Health):
+        pass
+
+    for ent_id in entities_to_kill:
+        if esper.entity_exists(ent_id):
+            esper.delete_entity(ent_id, immediate=False)
+
+    create_entities(new_entities_to_create)
+
+    esper.clear_dead_entities()
+
+
 #################################################
 # Perform several queries, and print the results:
 #################################################
 results = {1: {}, 2: {}, 3: {}}
+# result_times = []
+new_results = {"Rare Comp": {}, "Dynamic World": {}}
 result_times = []
 
 for amount in range(500, MAX_ENTITIES, MAX_ENTITIES//50):
@@ -163,6 +223,40 @@ for amount in range(500, MAX_ENTITIES, MAX_ENTITIES//50):
     gc.collect()
 
 
+print("\n--- Benchmarking: Optimized Scenarios ---")
+
+for amount in range(500, MAX_ENTITIES, MAX_ENTITIES//50):
+    create_mixed_entities(amount)
+    for _ in range(50):
+        rare_comp_query()
+    result_min = min(result_times)
+    print("Query rare component, {} Entities: {:f} ms".format(amount, result_min))
+    new_results["Rare Comp"][amount] = result_min
+    result_times = []
+    esper.clear_database()
+    gc.collect()
+
+for amount in range(500, MAX_ENTITIES, MAX_ENTITIES//50):
+    create_entities(amount)
+    all_entities = list(esper._entities.keys())
+    k = min(10, len(all_entities))
+    entities_to_kill_per_frame = random.sample(all_entities, k=k)
+
+    for _ in range(50):
+        dynamic_world_frame(entities_to_kill_per_frame, 10)
+        all_entities = list(esper._entities.keys())
+        k = min(10, len(all_entities))
+        if k > 0:
+            entities_to_kill_per_frame = random.sample(all_entities, k=k)
+
+    result_min = min(result_times)
+    print("Dynamic world frame, {} Entities: {:f} ms".format(amount, result_min))
+    new_results["Dynamic World"][amount] = result_min
+    result_times = []
+    esper.clear_database()
+    gc.collect()
+
+
 #############################################
 # Save the results to disk, or plot directly:
 #############################################
@@ -177,6 +271,7 @@ if options.plot:
         print("\nThe matplotlib module is required for plotting results.")
         sys.exit(1)
 
+    plt.figure(1)
     lines = []
     for num, result in results.items():
         x, y = zip(*sorted(result.items()))
@@ -185,5 +280,19 @@ if options.plot:
 
     plt.ylabel("Query Time (ms)")
     plt.xlabel("Number of Entities")
+    plt.title("Basic Component Queries")
     plt.legend(handles=lines, bbox_to_anchor=(0.5, 1))
+
+    plt.figure(2)
+    lines = []
+    for name, result in new_results.items():
+        if result:
+            x, y = zip(*sorted(result.items()))
+            lines.extend(plt.plot(x, y, label=name, marker='o'))
+
+    plt.ylabel("Query Time (ms)")
+    plt.xlabel("Number of Entities")
+    plt.title("Optimized Scenarios")
+    plt.legend(handles=lines, bbox_to_anchor=(0.5, 1))
+
     plt.show()


### PR DESCRIPTION
Hi Ben,

First off, thanks for creating Esper! I'm a big fan of its clean API and focus on performance.

I was looking through the open issues and saw the discussion in #115 about get_components performance. It's a great point, and it inspired me to take a deeper look and see if I could implement that optimization while staying 100% within the "pure Python" rule.

This PR is the result of that exploration. It directly addresses the suggestion in that issue and adds a few other performance tweaks.

Here’s a quick rundown of the main improvements:

    Smarter Multi-Component Queries: The biggest change is in get_components. It now intelligently finds the component with the fewest entities and iterates over that small set first. This makes queries with "rare" components (like a single Player component among hundreds of Enemy components) dramatically faster.

    Lazy Cache Invalidation: Instead of clearing the cache on every single change, the world now just marks it as "dirty." It only gets rebuilt on the next query, which cuts down on a lot of unnecessary work, especially in frames with lots of entity creation/deletion.

    Instant Processor Lookups: I switched the processor management from a list search to a dictionary lookup, so get_processor and remove_processor are now O(1) operations. It's a small change, but it feels right for a performance-oriented library.

To back this up, I've expanded the benchmark.py script with a couple of new scenarios that specifically highlight these improvements. The new "Rare Component" benchmark really shows off the new query logic in action.

I've also updated the unit tests to pass and added a few new ones to cover the new mechanics. I did my best to keep the changes clean and true to the spirit of the project.

Would love to get your feedback on this when you have a moment. Happy to discuss any of the changes or make adjustments.

Thanks again for your work on Esper!