### PR TITLE
Keey try_remove_component() from throwing a KeyError if the component isn't there

### DIFF
--- a/esper/__init__.py
+++ b/esper/__init__.py
@@ -461,7 +461,7 @@ def try_remove_component(entity: int, component_type: type[_C]) -> _C | None:
             del _components[component_type]
 
         clear_cache()
-        return _entities[entity].pop(component_type)  # type: ignore[no-any-return]
+        return _entities[entity].pop(component_type, None)  # type: ignore[no-any-return]
 
     return None
 


### PR DESCRIPTION
try_remove_component *was* actually throwing a KeyError if the entity didn't have the Component as it wasn't guarded by a check or a default value:

```python
return _entities[entity].pop(component_type)
```

Since the default for a non-extant Component type was to return None, I just added that default value to pop():

```python
return _entities[entity].pop(component_type, None)
```
